### PR TITLE
test: harden engine risk coverage and CI gate

### DIFF
--- a/.codex/memories/architecture.md
+++ b/.codex/memories/architecture.md
@@ -39,7 +39,7 @@
 
 ## Tests
 
-- Current tests in `tests/Game.test.ts` target selected `Grid` behavior.
+- `tests/Game.test.ts` now covers territory assignment, evolution rules (`nextState`, `computeNextStates`, `update`), assignment/snapshot deep-copy semantics, and `Game` constructor/win behavior.
 - No integration coverage yet for contexts/realtime flows.
 
 ## Delivery automation
@@ -47,7 +47,7 @@
 - GitHub Actions CI workflow lives in `.github/workflows/ci.yml`.
 - Workflow triggers on `push`, `pull_request`, and manual `workflow_dispatch`.
 - CI runner uses Node.js 20 with Yarn dependency caching and deterministic install via `yarn install --frozen-lockfile`.
-- Validation sequence runs `yarn ci` followed by `yarn build`.
+- Validation sequence runs targeted engine regression tests, then `yarn ci`, then `yarn build`.
 - Concurrency cancellation is enabled per branch/ref to avoid duplicate in-flight runs.
 
 ## Runtime resilience

--- a/.codex/memories/data-flow.md
+++ b/.codex/memories/data-flow.md
@@ -36,8 +36,9 @@
 
 1. GitHub `push`, `pull_request`, or manual dispatch triggers `.github/workflows/ci.yml`.
 2. Runner checks out repository and installs dependencies from `yarn.lock`.
-3. `yarn ci` runs lint, type check, and unit tests in sequence.
-4. `yarn build` validates production build compilation in the same pipeline run.
+3. Targeted engine regression suite runs with `yarn test --runInBand tests/Game.test.ts`.
+4. `yarn ci` runs lint, type check, and full unit tests in sequence.
+5. `yarn build` validates production build compilation in the same pipeline run.
 
 ## Missing-env fallback flow
 

--- a/.codex/memories/decision-log.md
+++ b/.codex/memories/decision-log.md
@@ -37,3 +37,19 @@ Append only. Do not rewrite past entries; add a new entry for reversals.
 - Context: Vercel status remained failed after env-guard changes, suggesting some deployments may still have partial/invalid Supabase configuration that can fail during server-side calls.
 - Decision: Wrap server-side Supabase auth/profile calls in `try/catch` and return safe fallback UI/state instead of throwing.
 - Rationale: Prevent transient or misconfigured Supabase connectivity from blocking deployments or static generation.
+
+## 2026-03-06 - Engine regression test expansion for optimization safety
+
+- Context: Future engine optimizations could unintentionally change deterministic rule outcomes, while existing tests mostly covered territory seeding and grid cloning.
+- Decision: Expand `tests/Game.test.ts` with deterministic regression coverage for `Grid.nextState`, `Grid.computeNextStates`, `Grid.update`, `Grid.assignCells`, and `Game.checkWin` fortress boundary handling.
+- Rationale: Protect gameplay rules with behavior-level assertions so implementation-level optimization can proceed safely.
+- Consequences: Unit test scope increases slightly, but confidence in refactor safety improves.
+- Follow-up: Add context/state-machine transition tests when turn-flow logic is optimized.
+
+## 2026-03-06 - Explicit engine-risk CI gate
+
+- Context: Need faster signal on rule regressions while optimizing the game engine and preserving deterministic behavior.
+- Decision: Add a dedicated CI step that runs `yarn test --runInBand tests/Game.test.ts` before the broader `yarn ci` and build steps.
+- Rationale: Fails fast on the highest-risk engine contract while keeping full lint/type/full-test/build coverage.
+- Consequences: Engine tests run twice in CI (targeted + full suite) but improve failure diagnostics.
+- Follow-up: Split test suites by domain if test volume grows enough to require runtime optimization.

--- a/.codex/memories/worklog/2026-03.md
+++ b/.codex/memories/worklog/2026-03.md
@@ -4,6 +4,22 @@ Append only. Add newest entries at the top.
 
 ## 2026-03-06
 
+- Task: Expand risky engine regression coverage, fix constructor player-selection precedence, and gate CI with explicit engine test execution before full validation/build.
+- Files touched: `tests/Game.test.ts`, `src/Game.ts`, `.github/workflows/ci.yml`, `.codex/memories/architecture.md`, `.codex/memories/data-flow.md`, `.codex/memories/decision-log.md`, `.codex/memories/worklog/2026-03.md`.
+- Validation: Ran `yarn test --runInBand tests/Game.test.ts`, `yarn lint`, `yarn typecheck`, `yarn test`, and `yarn build`.
+- Blocked checks: None.
+- Next step: Push branch, open PR, and confirm GitHub Actions CI completes successfully on the PR.
+
+## 2026-03-06
+
+- Task: Robustify engine behavior for future optimization by adding deterministic regression tests in the game engine suite.
+- Files touched: `tests/Game.test.ts`, `.codex/memories/decision-log.md`, `.codex/memories/worklog/2026-03.md`.
+- Validation: Ran `yarn test --runInBand tests/Game.test.ts`, `yarn lint`, `yarn typecheck`, and `yarn test`.
+- Blocked checks: None.
+- Next step: Reuse these guardrails during upcoming engine optimization work and add scenario-specific regressions as needed.
+
+## 2026-03-06
+
 - Task: Harden Supabase server-component calls with exception fallback after initial CI fix to address remaining Vercel deployment failure risk.
 - Files touched: `src/app/page.tsx`, `src/app/components/login.tsx`, `src/app/leaderboard/page.tsx`, `.codex/memories/architecture.md`, `.codex/memories/data-flow.md`, `.codex/memories/decision-log.md`, `.codex/memories/worklog/2026-03.md`.
 - Validation: Ran `yarn lint`, `yarn typecheck`, `yarn test --runInBand`, and network-enabled `yarn build`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
+      - name: Engine regression tests
+        run: yarn test --runInBand tests/Game.test.ts
+
       - name: Lint, typecheck, and tests
         run: yarn ci
 

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -194,7 +194,7 @@ export class Game {
     this.fortressCfg = fortressCfg;
     this.grid = new Grid(size, this.initialStates());
     this.initialPlayer =
-      initialPlayer || Math.random() < 0.5 ? CellState.A : CellState.B;
+      initialPlayer ?? (Math.random() < 0.5 ? CellState.A : CellState.B);
   }
 
   initialStates() {

--- a/tests/Game.test.ts
+++ b/tests/Game.test.ts
@@ -1,4 +1,4 @@
-import { Grid } from "@/Game";
+import { Game, Grid } from "@/Game";
 import { CellState, Territory } from "@/constants";
 
 const CA = CellState.A;
@@ -9,6 +9,28 @@ const TA = Territory.A;
 const TB = Territory.B;
 const TAB = Territory.AB;
 const TE = Territory.EMPTY;
+
+const createEmptyStates = (size: number): CellState[][] =>
+  Array.from({ length: size }, () => Array(size).fill(CE));
+
+const expectGridStates = (grid: Grid, expectedStates: CellState[][]) => {
+  for (let i = 0; i < grid.size; i++) {
+    for (let j = 0; j < grid.size; j++) {
+      expect(grid.cells[i][j].state).toEqual(expectedStates[i][j]);
+    }
+  }
+};
+
+const expectGridTerritories = (
+  grid: Grid,
+  expectedTerritories: Territory[][]
+) => {
+  for (let i = 0; i < grid.size; i++) {
+    for (let j = 0; j < grid.size; j++) {
+      expect(grid.cells[i][j].territory).toEqual(expectedTerritories[i][j]);
+    }
+  }
+};
 
 describe("Grid", () => {
   describe("computeTerritories", () => {
@@ -163,6 +185,231 @@ describe("Grid", () => {
       grid.cells[0][0].state = CA;
       expect(grid.cells[0][0].state).toEqual(CA);
       expect(clonedGrid.cells[0][0].state).toEqual(CE);
+    });
+  });
+
+  describe("nextState", () => {
+    it("should spawn player A when there are exactly three neighbors and A is in majority", () => {
+      const initStates = [
+        [CA, CE, CE],
+        [CB, CE, CA],
+        [CE, CE, CE],
+      ];
+      const grid = new Grid(3, initStates);
+
+      expect(grid.nextState(1, 1)).toEqual(CA);
+    });
+
+    it("should spawn player B when there are exactly three neighbors and B is in majority", () => {
+      const initStates = [
+        [CB, CE, CE],
+        [CA, CE, CB],
+        [CE, CE, CE],
+      ];
+      const grid = new Grid(3, initStates);
+
+      expect(grid.nextState(1, 1)).toEqual(CB);
+    });
+
+    it("should remove a living cell by underpopulation when it has fewer than two neighbors", () => {
+      const initStates = [
+        [CE, CE, CE],
+        [CE, CA, CA],
+        [CE, CE, CE],
+      ];
+      const grid = new Grid(3, initStates);
+
+      expect(grid.nextState(1, 1)).toEqual(CE);
+    });
+
+    it("should remove a living cell by overpopulation when it has more than three neighbors", () => {
+      const initStates = [
+        [CA, CA, CA],
+        [CA, CA, CE],
+        [CE, CE, CE],
+      ];
+      const grid = new Grid(3, initStates);
+
+      expect(grid.nextState(1, 1)).toEqual(CE);
+    });
+
+    it("should keep a living cell alive when it has two neighbors", () => {
+      const initStates = [
+        [CA, CE, CE],
+        [CE, CA, CA],
+        [CE, CE, CE],
+      ];
+      const grid = new Grid(3, initStates);
+
+      expect(grid.nextState(1, 1)).toEqual(CA);
+    });
+  });
+
+  describe("computeNextStates", () => {
+    it("should compute next states from a snapshot without mutating current grid state", () => {
+      const initStates = [
+        [CE, CE, CE, CE, CE],
+        [CE, CE, CA, CE, CE],
+        [CE, CE, CA, CE, CE],
+        [CE, CE, CA, CE, CE],
+        [CE, CE, CE, CE, CE],
+      ];
+      const grid = new Grid(5, initStates);
+
+      const nextStates = grid.computeNextStates();
+      const expectedStates = [
+        [CE, CE, CE, CE, CE],
+        [CE, CE, CE, CE, CE],
+        [CE, CA, CA, CA, CE],
+        [CE, CE, CE, CE, CE],
+        [CE, CE, CE, CE, CE],
+      ];
+
+      expect(nextStates).toEqual(expectedStates);
+      expect(grid.cells[1][2].state).toEqual(CA);
+      expect(grid.cells[2][1].state).toEqual(CE);
+    });
+  });
+
+  describe("update", () => {
+    it("should apply precomputed next states and recompute territories consistently", () => {
+      const initStates = [
+        [CE, CE, CE, CE, CE],
+        [CE, CE, CA, CE, CE],
+        [CE, CE, CA, CE, CE],
+        [CE, CE, CA, CE, CE],
+        [CE, CE, CE, CE, CE],
+      ];
+      const grid = new Grid(5, initStates);
+
+      const expectedStates = grid.computeNextStates();
+      const expectedTerritories = grid.computeTerritories(5, expectedStates);
+
+      grid.update();
+
+      expectGridStates(grid, expectedStates);
+      expectGridTerritories(grid, expectedTerritories);
+    });
+  });
+
+  describe("assignCells", () => {
+    it("should replace states and territories without sharing references to the input matrix", () => {
+      const grid = new Grid(3, createEmptyStates(3));
+      const assignedStates = [
+        [CE, CA, CE],
+        [CB, CE, CE],
+        [CE, CE, CE],
+      ];
+      const expectedTerritories = grid.computeTerritories(3, assignedStates);
+
+      grid.assignCells(assignedStates);
+      expectGridStates(grid, assignedStates);
+      expectGridTerritories(grid, expectedTerritories);
+
+      assignedStates[0][1] = CE;
+      assignedStates[2][2] = CA;
+      expect(grid.cells[0][1].state).toEqual(CA);
+      expect(grid.cells[2][2].state).toEqual(CE);
+
+      grid.cells[1][0].state = CE;
+      expect(assignedStates[1][0]).toEqual(CB);
+    });
+  });
+});
+
+describe("Game", () => {
+  const fortressCfg = {
+    a: { x: 0, y: 0, width: 2, height: 2 },
+    b: { x: 2, y: 2, width: 2, height: 2 },
+  };
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("constructor", () => {
+    it("should keep the provided initial player", () => {
+      const gameA = new Game(4, fortressCfg, CA);
+      const gameB = new Game(4, fortressCfg, CB);
+
+      expect(gameA.initialPlayer).toBe(CA);
+      expect(gameB.initialPlayer).toBe(CB);
+    });
+
+    it("should choose player A when random is below 0.5 and no player is provided", () => {
+      jest.spyOn(Math, "random").mockReturnValue(0.49);
+
+      const game = new Game(4, fortressCfg);
+
+      expect(game.initialPlayer).toBe(CA);
+    });
+
+    it("should choose player B when random is at or above 0.5 and no player is provided", () => {
+      jest.spyOn(Math, "random").mockReturnValue(0.5);
+
+      const game = new Game(4, fortressCfg);
+
+      expect(game.initialPlayer).toBe(CB);
+    });
+  });
+
+  describe("checkWin", () => {
+    it("should return false when no fortress is occupied by the opponent", () => {
+      const game = new Game(4, fortressCfg, CA);
+
+      game.grid.assignCells(createEmptyStates(4));
+
+      expect(game.checkWin()).toBe(false);
+    });
+
+    it("should declare player B winner when B occupies a boundary cell in fortress A", () => {
+      const game = new Game(4, fortressCfg, CA);
+      const states = createEmptyStates(4);
+      states[1][1] = CB;
+
+      game.grid.assignCells(states);
+
+      expect(game.checkWin()).toBe(CB);
+    });
+
+    it("should declare player A winner when A occupies a boundary cell in fortress B", () => {
+      const game = new Game(4, fortressCfg, CA);
+      const states = createEmptyStates(4);
+      states[3][3] = CA;
+
+      game.grid.assignCells(states);
+
+      expect(game.checkWin()).toBe(CA);
+    });
+
+    it("should prioritize fortress A breach when both fortresses are breached in the same state", () => {
+      const game = new Game(4, fortressCfg, CA);
+      const states = createEmptyStates(4);
+      states[0][0] = CB;
+      states[3][3] = CA;
+
+      game.grid.assignCells(states);
+
+      expect(game.checkWin()).toBe(CB);
+    });
+  });
+
+  describe("getCellStates", () => {
+    it("should return a deep copy of the current grid states", () => {
+      const game = new Game(4, fortressCfg, CA);
+      const states = createEmptyStates(4);
+      states[0][1] = CA;
+      states[2][2] = CB;
+      game.grid.assignCells(states);
+
+      const snapshot = game.getCellStates();
+      expect(snapshot).toEqual(states);
+
+      snapshot[0][1] = CE;
+      expect(game.grid.cells[0][1].state).toBe(CA);
+
+      game.grid.cells[2][2].state = CE;
+      expect(snapshot[2][2]).toBe(CB);
     });
   });
 });


### PR DESCRIPTION
## Summary
- expand engine regression tests for risky deterministic paths (nextState, computeNextStates, update, assignCells, constructor/player selection, checkWin, and getCellStates copy semantics)
- fix Game constructor initial player precedence by using nullish fallback so explicit player inputs are preserved
- add an explicit engine regression test step in CI before full yarn ci and build
- update .codex/memories architecture/data-flow snapshots, decision log, and worklog

## Validation
- yarn test --runInBand tests/Game.test.ts
- yarn ci
- yarn build